### PR TITLE
Fix #contain_error RSpec matcher

### DIFF
--- a/spec/vobject_spec.rb
+++ b/spec/vobject_spec.rb
@@ -21,7 +21,7 @@ end
 
 RSpec::Matchers.define :contain_error do |expected|
   match do |actual|
-    actual.select { |a| a =~ expected }
+    actual.any? { |err| err.inspect =~ expected }
   end
 end
 


### PR DESCRIPTION
Fix a custom matcher, which was always passing for any value/expectation pair.  This also fixes a Ruby warning about using `Object#=~` method, which used to be displayed.

Fixes #17.